### PR TITLE
Remove duplicate HeroSlider rendering

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,7 +4,6 @@ import GooeyNav from './components/GooeyNav/GooeyNav.jsx';
 import GradualBlur from './components/GradualBlur/GradualBlur.jsx';
 import FlowingMenu from './components/FlowingMenu/FlowingMenu.jsx';
 import SidebarMenu from './components/SidebarMenu/SidebarMenu.jsx';
-import HeroSlider from './components/HeroSlider/HeroSlider.jsx';
 import MotionShowcase from './components/MotionShowcase/MotionShowcase.jsx';
 import ImpactTicker from './components/ImpactTicker/ImpactTicker.jsx';
 import ProjectSpotlight from './components/ProjectSpotlight/ProjectSpotlight.jsx';
@@ -161,7 +160,6 @@ function App() {
             <p className="app__subtext">From concept to conversion, we launch immersive brand universes that convert attention into momentum.</p>
           </div>
         </header>
-        <HeroSlider />
         <ImpactTicker />
         <MotionShowcase />
         <ProjectSpotlight />


### PR DESCRIPTION
## Summary
- remove the redundant HeroSlider instance from the secondary main content block so the slider only renders in the hero section

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e0f09afa6483248843a1c2a40ecac5